### PR TITLE
display $\epsilon$ in lslisting correctly

### DIFF
--- a/chapters/parsing.tex
+++ b/chapters/parsing.tex
@@ -53,9 +53,9 @@ Left-factoring a grammar can make it LL(1): If there is a common prefix we can a
 
 Becomes:\smallskip
 
-\begin{lstlisting}		
+\begin{lstlisting}[escapeinside='']
 	S -> b_1 S` | ... | b_m S`		
-	S` -> a_1 S` | ... | a_n S` | $\epsilon$
+	S` -> a_1 S` | ... | a_n S` | '$\epsilon$'
 \end{lstlisting}\medskip
 
 


### PR DESCRIPTION
Internet also said that instead [mathescape=true] should work, but this gives me an error and couldn't make it work.